### PR TITLE
rightsreport: Send-As-Filter per SID statt lokalisiertem Namen

### DIFF
--- a/Modules/rightsreport.ps1
+++ b/Modules/rightsreport.ps1
@@ -1,5 +1,7 @@
 $rightsreport = Generate-ReportHeader "rightsreport.png" "$l_perm_header"
 
+$selfSid = [System.Security.Principal.SecurityIdentifier]"S-1-5-10"
+
 $cells=@("$l_perm_mbx","$l_perm_database","$l_perm_user","$l_perm_permission")
 $rightsreport += Generate-HTMLTable "$l_perm_header2" $cells
 
@@ -32,7 +34,7 @@ foreach ($mailbox in $allmbx)
 						$rightsreport += New-HTMLTableLine $cells
 					}
 			}
-		$sendas = Get-ADPermission $mailbox.DistinguishedName | where {($_.ExtendedRights -like "*Send-As*") -and ($_.IsInherited -eq $false) -and -not ($_.User -like "NT AUTHORITY\SELF") -and -not ($_.User -like "NT-AUTORITÄT\SELBST")} 
+		$sendas = Get-ADPermission $mailbox.DistinguishedName | where {($_.ExtendedRights -like "*Send-As*") -and ($_.IsInherited -eq $false) -and ($_.User.SecurityIdentifier -ne $selfSid)}
 		if ($sendas)
 			{
 				foreach ($right in $sendas)


### PR DESCRIPTION
Das Literal "NT-AUTORITÄT\SELBST" zerlegt den Parser in Windows PowerShell 5.1: Die Datei ist UTF-8 ohne BOM, PS 5.1 liest sie mit der System-ANSI-Codepage, und die Multi-Byte-Sequenz des Umlauts bricht das String-Literal in Zeile 35. Folge ist eine Fehler-Kaskade bis Zeilenende (unterminated string, fehlende Klammern).

Statt Namen zu matchen wird nun gegen die well-known SID S-1-5-10 verglichen. Damit entfällt das Umlaut-Literal, und der Filter funktioniert zudem unabhängig von der Systemsprache.

fixes #9